### PR TITLE
Fix error on unset SERVER_SOFTWARE variable

### DIFF
--- a/src/Linfo/Traits/LinfoProcessedTrait.php
+++ b/src/Linfo/Traits/LinfoProcessedTrait.php
@@ -30,7 +30,7 @@ trait LinfoProcessedTrait
 
     public function setWebServerProcessed()
     {
-        return $_SERVER['SERVER_SOFTWARE'];
+        return (!empty($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : '');
     }
 
     public function setCpuProcessed()

--- a/src/Linfo/Traits/LinfoProcessedTrait.php
+++ b/src/Linfo/Traits/LinfoProcessedTrait.php
@@ -30,7 +30,7 @@ trait LinfoProcessedTrait
 
     public function setWebServerProcessed()
     {
-        return (!empty($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : '');
+        return ! empty($_SERVER['SERVER_SOFTWARE']) ? $_SERVER['SERVER_SOFTWARE'] : '';
     }
 
     public function setCpuProcessed()


### PR DESCRIPTION
If `$_SERVER['SERVER_SOFTWARE']` is not set, return empty string.
